### PR TITLE
Change: SDK Language key in trace attributes

### DIFF
--- a/postmansdk/main.go
+++ b/postmansdk/main.go
@@ -112,7 +112,7 @@ func (psdk *postmanSDK) installExportPipeline(
 	resources, err := resource.New(
 		context.Background(),
 		resource.WithAttributes(
-			attribute.String("library.language", "go"),
+			attribute.String("telemetry.sdk.language", "go"),
 			attribute.String(
 				pmutils.POSTMAN_COLLECTION_ID_ATTRIBUTE_NAME, psdk.Config.CollectionId,
 			),


### PR DESCRIPTION
Changes the SDK language key from `library.language` to `telemetry.sdk.language`. To maintain consistency among the SDKs