### PR TITLE
[AOB-368]Improve readability of exported spans in debug mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	go.opentelemetry.io/otel v1.14.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.14.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.14.0
+	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.14.0
 	go.opentelemetry.io/otel/sdk v1.14.0
 	go.opentelemetry.io/otel/trace v1.14.0
 )

--- a/go.sum
+++ b/go.sum
@@ -217,6 +217,8 @@ go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.14.0 h1:TKf2uAs2ueguzLaxOCB
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.14.0/go.mod h1:HrbCVv40OOLTABmOn1ZWty6CHXkU8DK/Urc43tHug70=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.14.0 h1:3jAYbRHQAqzLjd9I4tzxwJ8Pk/N6AqBcF6m1ZHrxG94=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.14.0/go.mod h1:+N7zNjIJv4K+DeX67XXET0P+eIciESgaFDBqh+ZJFS4=
+go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.14.0 h1:sEL90JjOO/4yhquXl5zTAkLLsZ5+MycAgX99SDsxGc8=
+go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.14.0/go.mod h1:oCslUcizYdpKYyS9e8srZEqM6BB8fq41VJBjLAE6z1w=
 go.opentelemetry.io/otel/sdk v1.14.0 h1:PDCppFRDq8A1jL9v6KMI6dYesaq+DFcDZvjsoGvxGzY=
 go.opentelemetry.io/otel/sdk v1.14.0/go.mod h1:bwIC5TjrNG6QDCHNWvW4HLHtUQ4I+VQDsnjhvyZCALM=
 go.opentelemetry.io/otel/trace v1.14.0 h1:wp2Mmvj41tDsyAJXiWDWpfNsOiIyd38fy85pyKcFq/M=

--- a/postmansdk/exporter/exporter.go
+++ b/postmansdk/exporter/exporter.go
@@ -2,7 +2,6 @@ package exporter
 
 import (
 	"context"
-	"fmt"
 
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
@@ -22,9 +21,7 @@ func (e *PostmanExporter) ExportSpans(ctx context.Context, ss []tracesdk.ReadOnl
 		return nil
 	}
 
-	pmutils.Log.Debug("Spans to be exported are")
-
-	for idx, span := range ss {
+	for _, span := range ss {
 		defer func() {
 			if r := recover(); r != nil {
 				pmutils.Log.Debug("Issue faced while running plugins.")
@@ -39,7 +36,6 @@ func (e *PostmanExporter) ExportSpans(ctx context.Context, ss []tracesdk.ReadOnl
 			plugins.Redact(span, e.Sdkconfig.Options.RedactSensitiveData.Rules)
 		}
 
-		pmutils.Log.Debug(fmt.Printf("Span number:%d span:%+v", idx, span))
 	}
 	return e.Exporter.ExportSpans(ctx, ss)
 }


### PR DESCRIPTION
### Why
- Debug mode of SDK prints out the spans being sent to backend
- Current output is unreadable


#### Limitations
- Plugins run at the exporter level, while ConsoleExporter is registered with BatchSpanProcesssor
- Truncated/Redacted changes might not show up ?