### PR TITLE
feat: add user agent in receiver client

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,4 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
 
-*   @piyush-daga
-*   @gmann42
+*   @piyush-daga @gmann42

--- a/postmansdk/receiver/client.go
+++ b/postmansdk/receiver/client.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	pminterfaces "github.com/postmanlabs/postman-sdk-go/postmansdk/interfaces"
+	utils "github.com/postmanlabs/postman-sdk-go/postmansdk/utils"
 )
 
 type SdkPayload struct {
@@ -44,7 +45,8 @@ func makePostRequest(urlPath string, payload interface{}, sdkconfig *pminterface
 		return ar
 	}
 
-	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add(utils.CONTENT_TYPE, utils.APPLICATION_JSON)
+	req.Header.Add(utils.USER_AGENT, utils.SDK_USER_AGENT)
 	req.Header.Add(X_API_KEY, sdkconfig.ApiKey)
 
 	resp, err := client.Do(req)

--- a/postmansdk/receiver/client.go
+++ b/postmansdk/receiver/client.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	pminterfaces "github.com/postmanlabs/postman-sdk-go/postmansdk/interfaces"
-	utils "github.com/postmanlabs/postman-sdk-go/postmansdk/utils"
+	pmutils "github.com/postmanlabs/postman-sdk-go/postmansdk/utils"
 )
 
 type SdkPayload struct {
@@ -45,8 +45,8 @@ func makePostRequest(urlPath string, payload interface{}, sdkconfig *pminterface
 		return ar
 	}
 
-	req.Header.Add(utils.CONTENT_TYPE, utils.APPLICATION_JSON)
-	req.Header.Add(utils.USER_AGENT, utils.SDK_USER_AGENT)
+	req.Header.Add(pmutils.CONTENT_TYPE, pmutils.APPLICATION_JSON)
+	req.Header.Add(pmutils.USER_AGENT, pmutils.SDK_USER_AGENT)
 	req.Header.Add(X_API_KEY, sdkconfig.ApiKey)
 
 	resp, err := client.Do(req)

--- a/postmansdk/utils/constants.go
+++ b/postmansdk/utils/constants.go
@@ -5,4 +5,10 @@ const (
 	POSTMAN_SDK_ENABLE_ENV_VAR_NAME        = "POSTMAN_SDK_ENABLE"
 	POSTMAN_SDK_VERSION_ATTRIBUTE_NAME     = "postman.sdk.version"
 	POSTMAN_DATA_TRUNCATION_ATTRIBUTE_NAME = "postman.dataTruncated"
+
+	// Receiver request client constants
+	APPLICATION_JSON = "application/json"
+	CONTENT_TYPE     = "Content-Type"
+	SDK_USER_AGENT   = "Postman-SDK-Go"
+	USER_AGENT       = "User-Agent"
 )

--- a/postmansdk/version.go
+++ b/postmansdk/version.go
@@ -1,3 +1,3 @@
 package postmansdk
 
-const POSTMAN_SDK_VERSION = "0.1.0"
+const POSTMAN_SDK_VERSION = "0.1.1"


### PR DESCRIPTION
### Why?
Postman's Cloudflare firewall has blocked all incoming calls from `go-http` client, in order to prevent spam content, due to which `/bootstrap` and `/healthcheck` calls are giving 403, `/traces` calls are working fine cause they don't send this user agent.

### What?
Will be sending a custom user agent for all the receiver client calls.

### How?
Just like we are adding content type and API key in headers before sending request will be adding `Postman-SDK-Go` as `User-Agent`